### PR TITLE
Fix typo in hint for move_semantics1.rs.

### DIFF
--- a/move_semantics/move_semantics1.rs
+++ b/move_semantics/move_semantics1.rs
@@ -37,6 +37,6 @@ fn fill_vec(vec: Vec<i32>) -> Vec<i32> {
 
 
 
-// So you've got the "cannot borrow immutable local variable `vec1` as mutable" error on line 8,
-// right? The fix for this is going to be adding one keyword, and the addition is NOT on line 8
+// So you've got the "cannot borrow immutable local variable `vec1` as mutable" error on line 10,
+// right? The fix for this is going to be adding one keyword, and the addition is NOT on line 10
 // where the error is.


### PR DESCRIPTION
When I compile the unedited example in the playground, I get the
error on line 10, not line 8. That's the case for stable, beta,
and nightly. I'm a rust newbie, so for all I know the error is
supposed to be on line 8, but isn't due to some bug. I'm just
correcting the hint to match what I'm seeing.

Thank you for this project! I'm having fun and learning.