### PR TITLE
Update hint to reflect new variable binding name

### DIFF
--- a/strings/strings2.rs
+++ b/strings/strings2.rs
@@ -36,6 +36,6 @@ fn is_a_color_word(attempt: &str) -> bool {
 
 
 
-// Yes, it would be really easy to fix this by just changing the value bound to `guess1` to be a
+// Yes, it would be really easy to fix this by just changing the value bound to `word` to be a
 // string slice instead of a `String`, wouldn't it?? There is a way to add one character to line
 // 5, though, that will coerce the `String` into a string slice.


### PR DESCRIPTION
The hint in the `strings2` exercise was referencing a variable binding from a previous commit.