### PR TITLE
Fix typo in hint text

### DIFF
--- a/move_semantics/move_semantics1.rs
+++ b/move_semantics/move_semantics1.rs
@@ -38,6 +38,6 @@ fn fill_vec(vec: Vec<i32>) -> Vec<i32> {
 
 
 
-// So you've got the "cannot borrow immutable local variable `vec1` as mutable" error on line 10,
-// right? The fix for this is going to be adding one keyword, and the addition is NOT on line 10
+// So you've got the "cannot borrow immutable local variable `vec1` as mutable" error on line 11,
+// right? The fix for this is going to be adding one keyword, and the addition is NOT on line 11
 // where the error is.


### PR DESCRIPTION
The referred to error is actually thrown on line 11

Off topic: Great intro to Rust!