### PR TITLE
Fixed two typos in hinttext

### DIFF
--- a/move_semantics/move_semantics1.rs
+++ b/move_semantics/move_semantics1.rs
@@ -38,6 +38,6 @@ fn fill_vec(vec: Vec<i32>) -> Vec<i32> {
 
 
 
-// So you've got the "cannot borrow immutable local variable `vec1` as mutable" error on line 10,
-// right? The fix for this is going to be adding one keyword, and the addition is NOT on line 10
+// So you've got the "cannot borrow immutable local variable `vec1` as mutable" error on line 11,
+// right? The fix for this is going to be adding one keyword, and the addition is NOT on line 11
 // where the error is.

--- a/move_semantics/move_semantics2.rs
+++ b/move_semantics/move_semantics2.rs
@@ -1,5 +1,5 @@
 // move_semantics2.rs
-// Make me compile without changing line 9! Scroll down for hints :)
+// Make me compile without changing line 10! Scroll down for hints :)
 
 pub fn main() {
     let vec0 = Vec::new();
@@ -40,7 +40,7 @@ fn fill_vec(vec: Vec<i32>) -> Vec<i32> {
 
 // So `vec0` is being *moved* into the function `fill_vec` when we call it on
 // line 6, which means it gets dropped at the end of `fill_vec`, which means we
-// can't use `vec0` again on line 9 (or anywhere else in `main` after the
+// can't use `vec0` again on line 10 (or anywhere else in `main` after the
 // `fill_vec` call for that matter). We could fix this in a few ways, try them
 // all!
 // 1. Make another, separate version of the data that's in `vec0` and pass that


### PR DESCRIPTION
The referred to errors are actually in lines 11 and 10 resp.

Off topic: Great intro to Rust!